### PR TITLE
Update mtl signalisation-codification-rpa.json reading

### DIFF
--- a/Curblr/conversion-datas/curblr-datamtl-convert/pannonceau_to_regulations.js
+++ b/Curblr/conversion-datas/curblr-datamtl-convert/pannonceau_to_regulations.js
@@ -21,7 +21,7 @@ const mtlDataJson = JSON.parse(mtlData);
 const mtlFeatur = mtlDataJson.features;
 
 const rpaCodeJson = fs.readFileSync('data/signalisation-codification-rpa_withRegulation.json');
-const rpaCode = JSON.parse(rpaCodeJson).reduce((acc,val)=>{acc[val.PANNEAU_ID_RPA]=val; return acc;},{});
+const rpaCode = JSON.parse(rpaCodeJson);
 
 mtlPot = mtlFeatur.reduce((acc,val)=>{
                 acc[val.properties.POTEAU_ID_POT]=acc[val.properties.POTEAU_ID_POT]?acc[val.properties.POTEAU_ID_POT]:[];

--- a/Curblr/conversion-datas/curblr-datamtl-convert/segment_to_curblr.js
+++ b/Curblr/conversion-datas/curblr-datamtl-convert/segment_to_curblr.js
@@ -7,7 +7,7 @@ file_p = process.argv[2];
 const inputGeojson = fs.readFileSync(file_p);
 const input = JSON.parse(inputGeojson);
 const rpaCodeJson = fs.readFileSync('data/signalisation-codification-rpa_withRegulation.json');
-let rpaCode = JSON.parse(rpaCodeJson).reduce((acc,val)=>{acc[val.PANNEAU_ID_RPA]=val; return acc;},{});
+let rpaCode = JSON.parse(rpaCodeJson);
 const agregateRpaCodeJson = fs.readFileSync('data/agregate-pannonceau-rpa.json');
 const agregateRpaCode = JSON.parse(agregateRpaCodeJson);
 


### PR DESCRIPTION
The format for signalisation-codification-rpa.json changed.

It previously looked like this:

```
[  
  {  
    "PANNEAU_ID_RPA": 1001,  
    "DESCRIPTION_RPA": "description1",  
    "CODE_RPA": "CO-DE-1"  
  },  
  {  
    "PANNEAU_ID_RPA": 1002,  
    "DESCRIPTION_RPA": "description2",  
    "CODE_RPA": "CO-DE-2"  
  }  
]
```

Now it looks like this:
```
{  
   "PANNEAU_ID_RPA": {  
     "1": 1001,  
     "2": 1002   
   },  
   "DESCRIPTION_RPA": {  
     "1": "description1",  
     "2": "description2"  
   },  
   "CODE_RPA": {  
     "1": "CO-DE-1",  
     "2": "CO-DE-2"  
   }  
}  
```

This PR updates the reading for this new format.